### PR TITLE
Don't normalize stings, check for object instead

### DIFF
--- a/lib/jsdom/level2/html.js
+++ b/lib/jsdom/level2/html.js
@@ -106,7 +106,7 @@ function define(elementClass, def) {
           }
           else {
             var s = val.toString();
-            if (n.normalize) {
+            if (typeof n === 'object' && n.normalize) { //  see GH-491
               s = n.normalize(s);
             }
             this.setAttribute(attr, s);


### PR DESCRIPTION
Fix for the `argument does not match any normalization form` as seen in https://github.com/wordpress-mobile/gutenberg-mobile/pull/617#pullrequestreview-205427915.

Similar to https://github.com/brentvatne/jsdom-jscore/blob/master/lib/jsdom/level2/html.js#L97, guard the call to `n.normalize()` with a check for type `object`.

h/t to @koke for spotting the bug.

Will self-merge this one.